### PR TITLE
feat: generate dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,33 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    labels: ['dependencies', 'auto-merge-from-default']
-    directory: '/'
+  - package-ecosystem: npm
+    labels:
+      - dependencies
+      - auto-merge-from-default
+    directory: /
     schedule:
-      interval: 'weekly'
+      interval: weekly
     versioning-strategy: increase
     groups:
       production-dependencies:
         applies-to: version-updates
-        dependency-type: 'production'
+        dependency-type: production
         update-types:
-          - 'minor'
-          - 'patch'
+          - minor
+          - patch
       development-dependencies:
         applies-to: version-updates
-        dependency-type: 'development'
+        dependency-type: development
         update-types:
-          - 'minor'
-          - 'patch'
+          - minor
+          - patch
     ignore:
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-minor']
+      - dependency-name: '@total-typescript/ts-reset'
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-minor
       - dependency-name: '*'
-        update-types: ['version-update:semver-major']
+        update-types:
+          - version-update:semver-major

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -127,6 +127,6 @@ export default [
   }),
 
   {
-    ignores: ['dist', 'coverage', 'extra'],
+    ignores: ['dist', 'coverage', 'extra', 'scripts'],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,13 +28,15 @@
         "msw": "^2.6.6",
         "prettier": "^3.4.1",
         "sass": "^1.81.0",
+        "semver": "^7.6.3",
         "source-map-explorer": "^2.5.3",
         "tailwindcss": "^3.4.15",
         "typescript": "~5.6",
         "typescript-eslint": "^8.16.0",
         "vite": "^6.0.1",
         "vite-tsconfig-paths": "^5.1.3",
-        "vitest": "^2.0.5"
+        "vitest": "^2.0.5",
+        "yaml": "^2.6.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8252,7 +8254,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10003,7 +10004,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
       "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --cache --write .",
     "format-check": "prettier --cache --check .",
     "lint": "eslint ./ --max-warnings 0",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "generate-dependabot-config": "node ./scripts/generate-dependabot-config.js"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
@@ -37,12 +38,14 @@
     "msw": "^2.6.6",
     "prettier": "^3.4.1",
     "sass": "^1.81.0",
+    "semver": "^7.6.3",
     "source-map-explorer": "^2.5.3",
     "tailwindcss": "^3.4.15",
     "typescript": "~5.6",
     "typescript-eslint": "^8.16.0",
     "vite": "^6.0.1",
     "vite-tsconfig-paths": "^5.1.3",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "yaml": "^2.6.1"
   }
 }

--- a/scripts/generate-dependabot-config.js
+++ b/scripts/generate-dependabot-config.js
@@ -1,0 +1,91 @@
+import semver from 'semver';
+import packageJson from '../package.json' with { type: 'json' };
+import yaml from 'yaml';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const allDependencies = {
+  ...packageJson.dependencies,
+  ...packageJson.devDependencies,
+};
+
+const dependabotIgnoredDependencyVersions = [];
+
+for (const dependencyName in allDependencies) {
+  const semverRange = allDependencies[dependencyName];
+
+  const currentVersionFromRange = semver.coerce(semverRange);
+
+  const nextPatch = `${currentVersionFromRange.major}.${currentVersionFromRange.minor}.${currentVersionFromRange.patch + 1}`;
+
+  const nextMinor = `${currentVersionFromRange.major}.${currentVersionFromRange.minor + 1}.0`;
+
+  const allowPatch = semver.satisfies(nextPatch, semverRange);
+
+  const allowMinor = semver.satisfies(nextMinor, semverRange);
+
+  const ignoredUpdateTypes = [];
+
+  if (!allowPatch) {
+    ignoredUpdateTypes.push('version-update:semver-patch');
+  }
+
+  if (!allowMinor) {
+    ignoredUpdateTypes.push('version-update:semver-minor');
+  }
+
+  if (ignoredUpdateTypes.length > 0) {
+    dependabotIgnoredDependencyVersions.push({
+      'dependency-name': dependencyName,
+      'update-types': ignoredUpdateTypes,
+    });
+  }
+}
+
+const dependabotConfig = {
+  version: 2,
+  updates: [
+    {
+      'package-ecosystem': 'npm',
+      labels: ['dependencies', 'auto-merge-from-default'],
+      directory: '/',
+      schedule: { interval: 'weekly' },
+      'versioning-strategy': 'increase',
+      groups: {
+        'production-dependencies': {
+          'applies-to': 'version-updates',
+          'dependency-type': 'production',
+          'update-types': ['minor', 'patch'],
+        },
+        'development-dependencies': {
+          'applies-to': 'version-updates',
+          'dependency-type': 'development',
+          'update-types': ['minor', 'patch'],
+        },
+      },
+      ignore: [
+        ...dependabotIgnoredDependencyVersions,
+        {
+          'dependency-name': '*',
+          'update-types': ['version-update:semver-major'],
+        },
+      ],
+    },
+  ],
+};
+
+const yamlSerializerOptions = {
+  singleQuote: true,
+};
+
+const dependabotConfigYaml = yaml.stringify(
+  dependabotConfig,
+  yamlSerializerOptions
+);
+
+await fs.mkdir(path.resolve('.github'), { recursive: true });
+await fs.writeFile(
+  path.join('.github', 'dependabot.yml'),
+  dependabotConfigYaml,
+  { encoding: 'utf8' }
+);


### PR DESCRIPTION
Generates `.github/dependabot.yml` with a script that generates `ignore` [dependabot config option](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore) entries to enforce simple SemVer Range constraints from `package.json`.