### PR TITLE
feat: add generate dependabot config tool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,38 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    labels: ['dependencies', 'auto-merge-from-default']
-    directory: '/'
+  - package-ecosystem: npm
+    labels:
+      - dependencies
+    directory: /
     schedule:
-      interval: 'weekly'
+      interval: weekly
     versioning-strategy: increase
     groups:
       production-dependencies:
         applies-to: version-updates
-        dependency-type: 'production'
+        dependency-type: production
         update-types:
-          - 'minor'
-          - 'patch'
+          - minor
+          - patch
       development-dependencies:
         applies-to: version-updates
-        dependency-type: 'development'
+        dependency-type: development
         update-types:
-          - 'minor'
-          - 'patch'
+          - minor
+          - patch
+      production-security-fixes:
+        applies-to: security-updates
+        dependency-type: production
+      development-security-fixes:
+        applies-to: security-updates
+        dependency-type: development
     ignore:
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-minor']
+      - dependency-name: '@total-typescript/ts-reset'
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-minor
       - dependency-name: '*'
-        update-types: ['version-update:semver-major']
+        update-types:
+          - version-update:semver-major

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "vite-workshop",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "postinstall": "npx @elbaph/generate-dependabot-config-from-package-json --no-major-updates",
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
Generates `.github/dependabot.yml` with a [CLI tool](https://www.npmjs.com/package/@elbaph/generate-dependabot-config-from-package-json) that generates `ignore` [dependabot config option](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore) entries to enforce simple SemVer Range constraints from `package.json`.

