### PR TITLE
fix: add auto-merge-from-default label back to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   - package-ecosystem: npm
     labels:
       - dependencies
+      - auto-merge-from-default
     directory: /
     schedule:
       interval: weekly

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "postinstall": "npx @elbaph/generate-dependabot-config-from-package-json --no-major-updates",
+    "postinstall": "npx @elbaph/generate-dependabot-config-from-package-json --no-major-updates --labels dependencies,auto-merge-from-default",
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
When adding the dependabot generation script I have forgotten to include the `auto-merge-from-default` label in the dependabot.yml config, this PR fixes that.